### PR TITLE
FIX #101

### DIFF
--- a/collector/browser-session.js
+++ b/collector/browser-session.js
@@ -63,7 +63,7 @@ async function createBrowserSession(browser_args, browser_logger) {
       );
     });
 
-    var refs_regexp = new RegExp(`^(${uri_refs_stripped.join("|")})\\b`, "i");
+    var refs_regexp = new RegExp(`^(${uri_refs_stripped.join("|")})$`, "i");
 
     // load the page to traverse
     page = (await browser.pages())[0];


### PR DESCRIPTION
"first party classifier domain.org should not include domain.org.uy or other different TLDs"

Hi Robert,
this little fix should do the trick, tested on a few cases Tell me if it's OK for you

Thx, 
Franck